### PR TITLE
解决在32位PHP环境下随机数生成器报边界超出整数范围错误的问题.

### DIFF
--- a/Uploader.php
+++ b/Uploader.php
@@ -272,7 +272,7 @@ class Uploader
         $format = str_replace("{filename}", $oriName, $format);
 
         //替换随机字符串
-        $randNum = rand(1, 10000000000) . rand(1, 10000000000);
+        $randNum = mt_rand(1, 1000000000) . mt_rand(1, 1000000000);
         if (preg_match("/\{rand\:([\d]*)\}/i", $format, $matches)) {
             $format = preg_replace("/\{rand\:[\d]*\}/i", substr($randNum, 0, $matches[1]), $format);
         }


### PR DESCRIPTION
32位的php,最大值是20多亿,但是官方给的有11位数字,并且使用比较低效的rand算法.使用mt_rand更加高效.
